### PR TITLE
Update trc-20-contract-interaction.md

### DIFF
--- a/networks/tron-network/trx-and-trc-token/trc-20/trc-20-contract-interaction.md
+++ b/networks/tron-network/trx-and-trc-token/trc-20/trc-20-contract-interaction.md
@@ -338,8 +338,8 @@ async function triggerSmartContract() {
         let contract = await tronWeb.contract().at(trc20ContractAddress);
         //Use send to execute a non-pure or modify smart contract method on a given smart contract that modify or change values on the blockchain.
         // These methods consume resources(bandwidth and energy) to perform as the changes need to be broadcasted out to the network.
-        let result await contract.transfer(
-            "TVDGp...", //address _to
+        let result = await contract.transfer(
+            address,  //address _to
             1000000   //amount
         ).send({
             feeLimit: 1000000


### PR DESCRIPTION
Minor detail, there was a missing = sign && since the variable address is declared and used in the other examples, perhaps use it on the call for consistency.